### PR TITLE
Fix handling repeated wrappers

### DIFF
--- a/schematics_proto3/types/wrappers.py
+++ b/schematics_proto3/types/wrappers.py
@@ -2,6 +2,7 @@
 import os
 import random
 
+from google.protobuf import wrappers_pb2
 from schematics.exceptions import ValidationError
 from schematics.types import IntType, FloatType, BooleanType, StringType, BaseType
 
@@ -12,7 +13,30 @@ __all__ = ['IntWrapperType', 'FloatWrapperType', 'BoolWrapperType',
            'StringWrapperType', 'BytesWrapperType']
 
 
+WRAPPER_TYPES = (
+    wrappers_pb2.Int32Value,
+    wrappers_pb2.Int64Value,
+    wrappers_pb2.BytesValue,
+    wrappers_pb2.StringValue,
+    wrappers_pb2.BoolValue,
+    wrappers_pb2.UInt32Value,
+    wrappers_pb2.UInt64Value,
+    wrappers_pb2.FloatValue,
+    wrappers_pb2.DoubleValue,
+)
+
+
 class WrapperTypeMixin(ProtobufTypeMixin):
+
+    def convert(self, value, context):
+        if value is Unset:
+            return Unset
+
+        # TODO: Is is avoidable to use this?
+        if isinstance(value, WRAPPER_TYPES):
+            value = value.value
+
+        return super().convert(value, context)
 
     def convert_protobuf(self, msg, field_name, field_names):
         # pylint: disable=no-self-use

--- a/tests/loading/repeated/test_wrapped.py
+++ b/tests/loading/repeated/test_wrapped.py
@@ -1,0 +1,355 @@
+# -*- coding:utf-8 -*-
+from unittest.mock import Mock
+
+import pytest
+from google.protobuf import wrappers_pb2
+from schematics.exceptions import DataError, ValidationError
+
+from schematics_proto3 import types
+from schematics_proto3.models import Model
+from schematics_proto3.types import IntWrapperType
+from schematics_proto3.unset import Unset
+from tests import schematics_proto3_tests_pb2 as pb2
+from tests.utils.randoms import value_for_primitive
+from tests.utils.wire import mimic_protobuf_wire_transfer
+
+
+##########################################
+#  Message fixtures                      #
+##########################################
+
+@pytest.fixture
+def msg_all_set():
+    msg = pb2.RepeatedWrapped()
+    msg.value.extend([
+        wrappers_pb2.Int32Value(value=value_for_primitive('int32_field'))
+        for _ in range(3)
+    ])
+
+    return mimic_protobuf_wire_transfer(msg)
+
+
+@pytest.fixture
+def msg_unsets():
+    return mimic_protobuf_wire_transfer(pb2.RepeatedWrapped())
+
+
+##########################################
+#  Model fixtures                        #
+##########################################
+
+@pytest.fixture
+def model_class_optional():
+
+    class ModelOptional(Model, protobuf_message=pb2.RepeatedWrapped):
+        value = types.RepeatedType(IntWrapperType())
+
+    return ModelOptional
+
+
+@pytest.fixture
+def model_class_required():
+
+    class ModelRequired(Model, protobuf_message=pb2.RepeatedWrapped):
+        value = types.RepeatedType(IntWrapperType(), required=True)
+
+    return ModelRequired
+
+
+@pytest.fixture
+def model_class_required_renamed():
+
+    class ModelRequiredRenamed(Model, protobuf_message=pb2.RepeatedWrapped):
+        custom_value = types.RepeatedType(
+            IntWrapperType(),
+            required=True,
+            metadata=dict(protobuf_field='value'),
+        )
+
+    return ModelRequiredRenamed
+
+
+@pytest.fixture
+def model_class_none_not_dumped():
+
+    class ModelNoneNotDumped(Model, protobuf_message=pb2.RepeatedWrapped):
+        value = types.RepeatedType(IntWrapperType())
+
+        class Options:
+            serialize_when_none = False
+
+    return ModelNoneNotDumped
+
+
+@pytest.fixture
+def model_class_field_renamed():
+
+    class ModelFieldRenamed(Model, protobuf_message=pb2.RepeatedWrapped):
+        custom_value = types.RepeatedType(
+            IntWrapperType(),
+            metadata=dict(protobuf_field='value'),
+        )
+
+    return ModelFieldRenamed
+
+
+@pytest.fixture
+def model_class_validated_factory():
+    def _factory(validator_func=None, inner_validator_func=None):
+        outer_validators = [validator_func] if validator_func else []
+        inner_validators = [inner_validator_func] if inner_validator_func else []
+
+        class ModelValidated(Model, protobuf_message=pb2.RepeatedWrapped):
+            value = types.RepeatedType(
+                IntWrapperType(validators=inner_validators),
+                validators=outer_validators,
+            )
+
+        return ModelValidated
+
+    return _factory
+
+
+@pytest.fixture
+def model_class_validated_renamed_factory():
+    def _factory(validator_func=None, inner_validator_func=None):
+        outer_validators = [validator_func] if validator_func else []
+        inner_validators = [inner_validator_func] if inner_validator_func else []
+
+        class ModelValidated(Model, protobuf_message=pb2.RepeatedWrapped):
+            custom_value = types.RepeatedType(
+                IntWrapperType(validators=inner_validators),
+                validators=outer_validators,
+                metadata=dict(protobuf_field='value'),
+            )
+
+        return ModelValidated
+
+    return _factory
+
+
+##########################################
+#  Tests                                 #
+##########################################
+
+def test_optional_all_set(model_class_optional, msg_all_set):
+    model = model_class_optional.load_protobuf(msg_all_set)
+    model.validate()
+
+    # check model instance fields
+    assert model.value == [val.value for val in msg_all_set.value]
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' in data
+    assert data['value'] == [val.value for val in msg_all_set.value]
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_optional_unsets(model_class_optional, msg_unsets):
+    model = model_class_optional.load_protobuf(msg_unsets)
+    model.validate()
+
+    # check model instance fields
+    assert model.value is Unset
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' in data
+    assert data['value'] is Unset
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_none_not_dumped_all_set(model_class_none_not_dumped, msg_all_set):
+    model = model_class_none_not_dumped.load_protobuf(msg_all_set)
+    model.validate()
+
+    # check model instance fields
+    assert model.value == [val.value for val in msg_all_set.value]
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' in data
+    assert data['value'] == [val.value for val in msg_all_set.value]
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_none_not_dumped_unsets(model_class_none_not_dumped, msg_unsets):
+    model = model_class_none_not_dumped.load_protobuf(msg_unsets)
+    model.validate()
+
+    # check model instance fields
+    assert model.value is Unset
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' not in data
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_required_unsets(model_class_required, msg_unsets):
+    with pytest.raises(DataError) as ex:
+        model_class_required.load_protobuf(msg_unsets)
+
+    errors = ex.value.to_primitive()
+    assert 'value' in errors
+    assert 'required' in errors['value'][0]
+
+
+def test_required_renamed_unsets(model_class_required_renamed, msg_unsets):
+    with pytest.raises(DataError) as ex:
+        model_class_required_renamed.load_protobuf(msg_unsets)
+
+    errors = ex.value.to_primitive()
+    assert 'custom_value' in errors
+    assert 'required' in errors['custom_value'][0]
+
+
+def test_renamed_all_set(model_class_field_renamed, msg_all_set):
+    model = model_class_field_renamed.load_protobuf(msg_all_set)
+    model.validate()
+
+    # check model instance fields
+    assert model.custom_value == [val.value for val in msg_all_set.value]
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'custom_value' in data
+    assert data['custom_value'] == [val.value for val in msg_all_set.value]
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_renamed_unsets(model_class_field_renamed, msg_unsets):
+    model = model_class_field_renamed.load_protobuf(msg_unsets)
+    model.validate()
+
+    # check model instance fields
+    assert model.custom_value is Unset
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'custom_value' in data
+    assert data['custom_value'] is Unset
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_validated_all_set(model_class_validated_factory, msg_all_set):
+    validator_func = Mock()
+    model_cls = model_class_validated_factory(validator_func)
+
+    model = model_cls.load_protobuf(msg_all_set)
+    model.validate()
+
+    # check model instance fields
+    assert model.value == [val.value for val in msg_all_set.value]
+    validator_func.assert_called_once_with(model.value)
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' in data
+    assert data['value'] == [val.value for val in msg_all_set.value]
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_validated_unsets(model_class_validated_factory, msg_unsets):
+    validator_func = Mock()
+    model_cls = model_class_validated_factory(validator_func)
+
+    model = model_cls.load_protobuf(msg_unsets)
+    model.validate()
+
+    # check model instance fields
+    assert model.value is Unset
+    validator_func.assert_not_called()
+
+    # check primitive dump
+    data = model.to_primitive()
+
+    assert 'value' in data
+    assert data['value'] is Unset
+
+    # compare dump to native
+    assert model.to_native() == data
+
+
+def test_validated_validation_error(model_class_validated_factory, msg_all_set):
+    validator_func = Mock(side_effect=ValidationError('Please speak up!'))
+    model_cls = model_class_validated_factory(validator_func)
+
+    model = model_cls.load_protobuf(msg_all_set)
+    with pytest.raises(DataError) as ex:
+        model.validate()
+
+    errors = ex.value.to_primitive()
+
+    assert 'value' in errors
+    assert 'Please speak up!' in errors['value'][0], f"`Please speak up!` in `{errors['value'][0]}`"
+
+
+def test_validated_validation_error__inner(model_class_validated_factory, msg_all_set):
+    validator_func = Mock(side_effect=ValidationError('Please speak up!'))
+    model_cls = model_class_validated_factory(None, validator_func)
+
+    model = model_cls.load_protobuf(msg_all_set)
+    with pytest.raises(DataError) as ex:
+        model.validate()
+
+    errors = ex.value.to_primitive()
+
+    assert 'value' in errors
+    assert len(errors['value']) == 3
+    assert 'Please speak up!' in errors['value'][0]
+    assert 'Please speak up!' in errors['value'][1]
+    assert 'Please speak up!' in errors['value'][2]
+
+
+def test_validated_validation_error_renamed(model_class_validated_renamed_factory, msg_all_set):
+    validator_func = Mock(side_effect=ValidationError('Please speak up!'))
+    model_cls = model_class_validated_renamed_factory(validator_func)
+
+    model = model_cls.load_protobuf(msg_all_set)
+    with pytest.raises(DataError) as ex:
+        model.validate()
+
+    errors = ex.value.to_primitive()
+
+    assert 'custom_value' in errors
+    assert 'Please speak up!' in errors['custom_value'][0], f"`Please speak up!` in `{errors['custom_value'][0]}`"
+
+
+def test_validated_validation_error_renamed__inner(model_class_validated_renamed_factory, msg_all_set):
+    validator_func = Mock(side_effect=ValidationError('Please speak up!'))
+    model_cls = model_class_validated_renamed_factory(None, validator_func)
+
+    model = model_cls.load_protobuf(msg_all_set)
+    with pytest.raises(DataError) as ex:
+        model.validate()
+
+    errors = ex.value.to_primitive()
+
+    assert 'custom_value' in errors
+    assert len(errors['custom_value']) == 3
+    assert 'Please speak up!' in errors['custom_value'][0]
+    assert 'Please speak up!' in errors['custom_value'][1]
+    assert 'Please speak up!' in errors['custom_value'][2]

--- a/tests/schematics_proto3_tests.proto
+++ b/tests/schematics_proto3_tests.proto
@@ -115,6 +115,10 @@ message RepeatedNested {
   repeated Inner inner = 1;
 }
 
+message RepeatedWrapped {
+  repeated google.protobuf.Int32Value value = 1;
+}
+
 /*
  * Messages for oneof tests.
  */

--- a/tests/schematics_proto3_tests_pb2.py
+++ b/tests/schematics_proto3_tests_pb2.py
@@ -23,7 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='schematics_proto3.tests',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n#tests/schematics_proto3_tests.proto\x12\x17schematics_proto3.tests\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"e\n\x06Nested\x12\x34\n\x05inner\x18\x01 \x01(\x0b\x32%.schematics_proto3.tests.Nested.Inner\x12\r\n\x05other\x18\x02 \x01(\t\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\t\">\n\rWrappedDouble\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.DoubleValue\"<\n\x0cWrappedFloat\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.FloatValue\"<\n\x0cWrappedInt64\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.Int64Value\">\n\rWrappedUInt64\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.UInt64Value\"<\n\x0cWrappedInt32\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.Int32Value\">\n\rWrappedUInt32\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.UInt32Value\":\n\x0bWrappedBool\x12+\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\">\n\rWrappedString\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"<\n\x0cWrappedBytes\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.BytesValue\"\x17\n\x06\x44ouble\x12\r\n\x05value\x18\x01 \x01(\x01\"\x16\n\x05\x46loat\x12\r\n\x05value\x18\x01 \x01(\x02\"\x16\n\x05Int64\x12\r\n\x05value\x18\x01 \x01(\x03\"\x17\n\x06UInt64\x12\r\n\x05value\x18\x01 \x01(\x04\"\x16\n\x05Int32\x12\r\n\x05value\x18\x01 \x01(\x05\"\x17\n\x06UInt32\x12\r\n\x05value\x18\x01 \x01(\r\"\x15\n\x04\x42ool\x12\r\n\x05value\x18\x01 \x01(\x08\"\x17\n\x06String\x12\r\n\x05value\x18\x01 \x01(\t\"\x16\n\x05\x42ytes\x12\r\n\x05value\x18\x01 \x01(\x0c\"\"\n\x11RepeatedPrimitive\x12\r\n\x05value\x18\x01 \x03(\t\"f\n\x0eRepeatedNested\x12<\n\x05inner\x18\x01 \x03(\x0b\x32-.schematics_proto3.tests.RepeatedNested.Inner\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\t\"=\n\x0eOneOfPrimitive\x12\x10\n\x06value1\x18\x01 \x01(\x04H\x00\x12\x10\n\x06value2\x18\x02 \x01(\tH\x00\x42\x07\n\x05inner\"\x9c\x01\n\x0bOneOfNested\x12<\n\x06value1\x18\x01 \x01(\x0b\x32*.schematics_proto3.tests.OneOfNested.InnerH\x00\x12.\n\x06value2\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValueH\x00\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\tB\x07\n\x05inner\":\n\nSimpleEnum\x12,\n\x05value\x18\x01 \x01(\x0e\x32\x1d.schematics_proto3.tests.Enum\"<\n\x0cRepeatedEnum\x12,\n\x05value\x18\x01 \x03(\x0e\x32\x1d.schematics_proto3.tests.Enum\"u\n\tOneOfEnum\x12.\n\x06value1\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.StringValueH\x00\x12/\n\x06value2\x18\x02 \x01(\x0e\x32\x1d.schematics_proto3.tests.EnumH\x00\x42\x07\n\x05inner**\n\x04\x45num\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05\x46IRST\x10\x01\x12\n\n\x06SECOND\x10\x02\x62\x06proto3')
+  serialized_pb=_b('\n#tests/schematics_proto3_tests.proto\x12\x17schematics_proto3.tests\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"e\n\x06Nested\x12\x34\n\x05inner\x18\x01 \x01(\x0b\x32%.schematics_proto3.tests.Nested.Inner\x12\r\n\x05other\x18\x02 \x01(\t\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\t\">\n\rWrappedDouble\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.DoubleValue\"<\n\x0cWrappedFloat\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.FloatValue\"<\n\x0cWrappedInt64\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.Int64Value\">\n\rWrappedUInt64\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.UInt64Value\"<\n\x0cWrappedInt32\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.Int32Value\">\n\rWrappedUInt32\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.UInt32Value\":\n\x0bWrappedBool\x12+\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\">\n\rWrappedString\x12-\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"<\n\x0cWrappedBytes\x12,\n\x07wrapped\x18\x01 \x01(\x0b\x32\x1b.google.protobuf.BytesValue\"\x17\n\x06\x44ouble\x12\r\n\x05value\x18\x01 \x01(\x01\"\x16\n\x05\x46loat\x12\r\n\x05value\x18\x01 \x01(\x02\"\x16\n\x05Int64\x12\r\n\x05value\x18\x01 \x01(\x03\"\x17\n\x06UInt64\x12\r\n\x05value\x18\x01 \x01(\x04\"\x16\n\x05Int32\x12\r\n\x05value\x18\x01 \x01(\x05\"\x17\n\x06UInt32\x12\r\n\x05value\x18\x01 \x01(\r\"\x15\n\x04\x42ool\x12\r\n\x05value\x18\x01 \x01(\x08\"\x17\n\x06String\x12\r\n\x05value\x18\x01 \x01(\t\"\x16\n\x05\x42ytes\x12\r\n\x05value\x18\x01 \x01(\x0c\"\"\n\x11RepeatedPrimitive\x12\r\n\x05value\x18\x01 \x03(\t\"f\n\x0eRepeatedNested\x12<\n\x05inner\x18\x01 \x03(\x0b\x32-.schematics_proto3.tests.RepeatedNested.Inner\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\t\"=\n\x0fRepeatedWrapped\x12*\n\x05value\x18\x01 \x03(\x0b\x32\x1b.google.protobuf.Int32Value\"=\n\x0eOneOfPrimitive\x12\x10\n\x06value1\x18\x01 \x01(\x04H\x00\x12\x10\n\x06value2\x18\x02 \x01(\tH\x00\x42\x07\n\x05inner\"\x9c\x01\n\x0bOneOfNested\x12<\n\x06value1\x18\x01 \x01(\x0b\x32*.schematics_proto3.tests.OneOfNested.InnerH\x00\x12.\n\x06value2\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValueH\x00\x1a\x16\n\x05Inner\x12\r\n\x05value\x18\x01 \x01(\tB\x07\n\x05inner\":\n\nSimpleEnum\x12,\n\x05value\x18\x01 \x01(\x0e\x32\x1d.schematics_proto3.tests.Enum\"<\n\x0cRepeatedEnum\x12,\n\x05value\x18\x01 \x03(\x0e\x32\x1d.schematics_proto3.tests.Enum\"u\n\tOneOfEnum\x12.\n\x06value1\x18\x01 \x01(\x0b\x32\x1c.google.protobuf.StringValueH\x00\x12/\n\x06value2\x18\x02 \x01(\x0e\x32\x1d.schematics_proto3.tests.EnumH\x00\x42\x07\n\x05inner**\n\x04\x45num\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05\x46IRST\x10\x01\x12\n\n\x06SECOND\x10\x02\x62\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,])
 
@@ -48,8 +48,8 @@ _ENUM = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1618,
-  serialized_end=1660,
+  serialized_start=1681,
+  serialized_end=1723,
 )
 _sym_db.RegisterEnumDescriptor(_ENUM)
 
@@ -778,6 +778,37 @@ _REPEATEDNESTED = _descriptor.Descriptor(
 )
 
 
+_REPEATEDWRAPPED = _descriptor.Descriptor(
+  name='RepeatedWrapped',
+  full_name='schematics_proto3.tests.RepeatedWrapped',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='value', full_name='schematics_proto3.tests.RepeatedWrapped.value', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1155,
+  serialized_end=1216,
+)
+
+
 _ONEOFPRIMITIVE = _descriptor.Descriptor(
   name='OneOfPrimitive',
   full_name='schematics_proto3.tests.OneOfPrimitive',
@@ -814,8 +845,8 @@ _ONEOFPRIMITIVE = _descriptor.Descriptor(
       name='inner', full_name='schematics_proto3.tests.OneOfPrimitive.inner',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1155,
-  serialized_end=1216,
+  serialized_start=1218,
+  serialized_end=1279,
 )
 
 
@@ -885,8 +916,8 @@ _ONEOFNESTED = _descriptor.Descriptor(
       name='inner', full_name='schematics_proto3.tests.OneOfNested.inner',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1219,
-  serialized_end=1375,
+  serialized_start=1282,
+  serialized_end=1438,
 )
 
 
@@ -916,8 +947,8 @@ _SIMPLEENUM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1377,
-  serialized_end=1435,
+  serialized_start=1440,
+  serialized_end=1498,
 )
 
 
@@ -947,8 +978,8 @@ _REPEATEDENUM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1437,
-  serialized_end=1497,
+  serialized_start=1500,
+  serialized_end=1560,
 )
 
 
@@ -988,8 +1019,8 @@ _ONEOFENUM = _descriptor.Descriptor(
       name='inner', full_name='schematics_proto3.tests.OneOfEnum.inner',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1499,
-  serialized_end=1616,
+  serialized_start=1562,
+  serialized_end=1679,
 )
 
 _NESTED_INNER.containing_type = _NESTED
@@ -1005,6 +1036,7 @@ _WRAPPEDSTRING.fields_by_name['wrapped'].message_type = google_dot_protobuf_dot_
 _WRAPPEDBYTES.fields_by_name['wrapped'].message_type = google_dot_protobuf_dot_wrappers__pb2._BYTESVALUE
 _REPEATEDNESTED_INNER.containing_type = _REPEATEDNESTED
 _REPEATEDNESTED.fields_by_name['inner'].message_type = _REPEATEDNESTED_INNER
+_REPEATEDWRAPPED.fields_by_name['value'].message_type = google_dot_protobuf_dot_wrappers__pb2._INT32VALUE
 _ONEOFPRIMITIVE.oneofs_by_name['inner'].fields.append(
   _ONEOFPRIMITIVE.fields_by_name['value1'])
 _ONEOFPRIMITIVE.fields_by_name['value1'].containing_oneof = _ONEOFPRIMITIVE.oneofs_by_name['inner']
@@ -1051,6 +1083,7 @@ DESCRIPTOR.message_types_by_name['String'] = _STRING
 DESCRIPTOR.message_types_by_name['Bytes'] = _BYTES
 DESCRIPTOR.message_types_by_name['RepeatedPrimitive'] = _REPEATEDPRIMITIVE
 DESCRIPTOR.message_types_by_name['RepeatedNested'] = _REPEATEDNESTED
+DESCRIPTOR.message_types_by_name['RepeatedWrapped'] = _REPEATEDWRAPPED
 DESCRIPTOR.message_types_by_name['OneOfPrimitive'] = _ONEOFPRIMITIVE
 DESCRIPTOR.message_types_by_name['OneOfNested'] = _ONEOFNESTED
 DESCRIPTOR.message_types_by_name['SimpleEnum'] = _SIMPLEENUM
@@ -1221,6 +1254,13 @@ RepeatedNested = _reflection.GeneratedProtocolMessageType('RepeatedNested', (_me
   ))
 _sym_db.RegisterMessage(RepeatedNested)
 _sym_db.RegisterMessage(RepeatedNested.Inner)
+
+RepeatedWrapped = _reflection.GeneratedProtocolMessageType('RepeatedWrapped', (_message.Message,), dict(
+  DESCRIPTOR = _REPEATEDWRAPPED,
+  __module__ = 'tests.schematics_proto3_tests_pb2'
+  # @@protoc_insertion_point(class_scope:schematics_proto3.tests.RepeatedWrapped)
+  ))
+_sym_db.RegisterMessage(RepeatedWrapped)
 
 OneOfPrimitive = _reflection.GeneratedProtocolMessageType('OneOfPrimitive', (_message.Message,), dict(
   DESCRIPTOR = _ONEOFPRIMITIVE,


### PR DESCRIPTION
For nested types, if I don't want to reimplement all the schematics API myself (instead of inheriting from List), I need to provide `convert` implementation for wrapper types.
This is not the perfect approach.